### PR TITLE
Remove dependency on `unstable/sandbox`

### DIFF
--- a/pict3d/scribblings/utils.rkt
+++ b/pict3d/scribblings/utils.rkt
@@ -9,7 +9,6 @@
 
 (require racket/match
          scribble/eval
-         unstable/sandbox
          racket/runtime-path
          racket/draw
          "serializable-bitmap.rkt"


### PR DESCRIPTION
The functionality of that library will be moved into Scribble by Scribble PR #12, and `unstable/sandbox` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the unstable-lib package, as it will not be part of the main distribution in future versions.
