### PR TITLE
Use `make-constructor-style-printer` from `racket/struct`.

### DIFF
--- a/pict3d/private/utils.rkt
+++ b/pict3d/private/utils.rkt
@@ -19,7 +19,7 @@
   (profile-thunk (λ () body ...)))
 
 (require/typed
- unstable/custom-write
+ racket/struct
  [make-constructor-style-printer
   (All (A) (-> (-> A (U Symbol String))
                (-> A (Sequenceof Any))


### PR DESCRIPTION
Moved there as of Racket 6.2.900.10.

This change is not compatible with Racket 6.2.1. You can address that by using a version exception.

Alternatively, you can add an explicit dependency to `unstable-lib`, which exports `unstable/struct` starting with Racket 6.2.900.10.
